### PR TITLE
Move and rename receive method for dynamic chainable values

### DIFF
--- a/Sources/KitUI/Extensions/NSObject.swift
+++ b/Sources/KitUI/Extensions/NSObject.swift
@@ -1,0 +1,23 @@
+import Foundation
+import ReactiveCocoa
+import ReactiveSwift
+
+// MARK: Experiment! Use at your own risk!
+extension NSObject {
+    
+    /// A generic, chainable method for piping values into an object at a certain keypath
+    /// - parameter keyPath: The keypath on the current object. It's possible to pass in a keypath
+    ///   that's incompatible with the current object. In that case this function will be a no-op
+    /// - parameter value: A `SignalProducerConvertible` value that will have it's values piped into
+    ///   the keypath
+    /// - returns: The object it's called on, for chainability
+    public func receive<T: SignalProducerConvertible, U: NSObject>(
+        _ keyPath: ReferenceWritableKeyPath<U, T.Value>,
+        _ value: T
+    ) -> Self {
+        if let self = self as? U {
+            self.reactive[keyPath] <~ value.producer.eraseError()
+        }
+        return self
+    }
+}

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -167,11 +167,13 @@ extension UIView {
     // MARK: Accessibility Chainables
     @discardableResult
     public func accessibilityLabel<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == String {
-        self.ds(\.accessibilityLabel, value.producer.map { $0 as String? })
+        self.reactive.accessibilityLabel <~ value.producer.eraseError()
+        return self
     }
     
     public func accessibilityLabel<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == String? {
-        self.ds(\.accessibilityLabel, value)
+        self.reactive.accessibilityLabel <~ value.producer.eraseError()
+        return self
     }
     
     @discardableResult
@@ -404,16 +406,6 @@ extension UIView {
         view.backgroundColor = .clear
         view.isUserInteractionEnabled = false
         return view
-    }
-}
-
-// MARK: Experiments! Use at your own risk!
-extension UIView {
-    public func ds<T: SignalProducerConvertible>(_ keyPath: ReferenceWritableKeyPath<UIView, T.Value>, _ value: T) -> Self {
-        value.producer.eraseError().take(duringLifetimeOf: self).startWithValues { [weak self] value in
-            self?[keyPath: keyPath] = value
-        }
-        return self
     }
 }
 

--- a/Tests/KitUITests/KitUITests.swift
+++ b/Tests/KitUITests/KitUITests.swift
@@ -1,0 +1,35 @@
+//
+//  KitUITests.swift
+//  
+//
+//  Created by Chris Brakebill on 10/3/22.
+//
+
+import XCTest
+
+final class KitUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/KitUITests/ReceiveTests.swift
+++ b/Tests/KitUITests/ReceiveTests.swift
@@ -1,0 +1,34 @@
+//
+//  ReceiveTests.swift
+//  
+//
+//  Created by Chris Brakebill on 10/3/22.
+//
+
+import XCTest
+@testable import KitUI
+import ReactiveSwift
+
+class TestObject: NSObject {
+    var value: Int = 0
+}
+
+final class ReceiveTests: XCTestCase {
+
+    func testReceive() throws {
+        
+        let (signal, observer) = Signal<Int, Never>.pipe()
+        var object = TestObject().receive(\TestObject.value, signal.producer)
+        
+        observer.send(value: 2)
+        XCTAssertEqual(object.value, 2)
+        
+        observer.send(value: 3)
+        XCTAssertEqual(object.value, 3)
+        
+        observer.send(value: 100)
+        XCTAssertEqual(object.value, 100)
+        
+        observer.sendCompleted()
+    }
+}


### PR DESCRIPTION
- Take this call out of the accessibility label code, not ready for that
- Move it to it's own file and add a basic unit test

I still want to find a better way to do this generically, this method currently allows incorrect keypath types. But I can't figure out how to specify it correctly. It may not be possible with Swift currently?