### PR TITLE
Updating to support primary associated types with ReactiveSwift

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveCocoa/ReactiveCocoa",
       "state" : {
-        "revision" : "579364393ad587352bcce133b7b3f73392cb585b",
-        "version" : "11.2.2"
+        "revision" : "8a5b07b18c6abb8e12fb845bf742675dc4914ed8",
+        "version" : "12.0.0"
       }
     },
     {
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/ReactiveCocoa/ReactiveSwift/",
       "state" : {
-        "revision" : "c43bae3dac73fdd3cb906bd5a1914686ca71ed3c",
-        "version" : "6.7.0"
+        "revision" : "509916c99f49a5e6c8196c968b8b7e3dbd48db04",
+        "version" : "7.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,8 +15,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", .upToNextMajor(from: "6.0.0")),
-        .package(url: "https://github.com/ReactiveCocoa/ReactiveCocoa", .upToNextMajor(from: "11.0.0")),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveSwift", .upToNextMajor(from: "7.0.0")),
+        .package(url: "https://github.com/ReactiveCocoa/ReactiveCocoa", .upToNextMajor(from: "12.0.0")),
         .package(url: "https://github.com/roberthein/TinyConstraints", .upToNextMajor(from: "4.0.0"))
     ],
     targets: [

--- a/Sources/KitUI/Extensions/AsyncStreams.swift
+++ b/Sources/KitUI/Extensions/AsyncStreams.swift
@@ -1,6 +1,8 @@
 //
 //  AsyncStreams.swift
-//  KitUI
+//
+//  These really belong somewhere else? Just a way to make signal producers
+//  conform to AsyncStreams?
 //
 //  Created by Chris Brakebill on 9/23/22.
 //

--- a/Sources/KitUI/Extensions/UIKit/UIActivityIndicatorView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIActivityIndicatorView.swift
@@ -24,7 +24,7 @@ extension UIActivityIndicatorView {
     /// - parameter color: A `Property` which will set & update the color on the view
     /// - returns: The `UIActivityIndicatorView` it's called on
     /// - note: **Modifying modifier** modifies a property of the `UIActivityIndicatorView`
-    public func color(_ color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+    public func color(_ color: some SignalProducerConvertible<UIColor, Never>) -> Self {
         self.reactive.color <~ color.producer
         return self
     }
@@ -33,7 +33,7 @@ extension UIActivityIndicatorView {
     /// - parameter isAnimating: A `Property` which will set & update the animating state on the view
     /// - returns: The `UIActivityIndicatorView` it's called on
     /// - note: **Modifying modifier** modifies a property of the `UIActivityIndicatorView`
-    public func isAnimating(_ isAnimating: any SignalProducerConvertible<Bool, Never>) -> Self {
+    public func isAnimating(_ isAnimating: some SignalProducerConvertible<Bool, Never>) -> Self {
         self.reactive.isAnimating <~ isAnimating.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIActivityIndicatorView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIActivityIndicatorView.swift
@@ -24,8 +24,8 @@ extension UIActivityIndicatorView {
     /// - parameter color: A `Property` which will set & update the color on the view
     /// - returns: The `UIActivityIndicatorView` it's called on
     /// - note: **Modifying modifier** modifies a property of the `UIActivityIndicatorView`
-    public func color<T: SignalProducerConvertible>(_ color: T) -> Self where T.Value == UIColor {
-        self.reactive.color <~ color.producer.eraseError()
+    public func color(_ color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+        self.reactive.color <~ color.producer
         return self
     }
     
@@ -33,8 +33,8 @@ extension UIActivityIndicatorView {
     /// - parameter isAnimating: A `Property` which will set & update the animating state on the view
     /// - returns: The `UIActivityIndicatorView` it's called on
     /// - note: **Modifying modifier** modifies a property of the `UIActivityIndicatorView`
-    public func isAnimating<T: SignalProducerConvertible>(_ isAnimating: T) -> Self where T.Value == Bool {
-        self.reactive.isAnimating <~ isAnimating.producer.eraseError()
+    public func isAnimating(_ isAnimating: any SignalProducerConvertible<Bool, Never>) -> Self {
+        self.reactive.isAnimating <~ isAnimating.producer
         return self
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UIButton.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIButton.swift
@@ -43,7 +43,7 @@ extension UIButton {
     /// - note: **Mutating modifier** modifies a property of the button
     @discardableResult
     public func title(
-        color: any SignalProducerConvertible<UIColor?, Never>,
+        color: some SignalProducerConvertible<UIColor?, Never>,
         state: UIControl.State = .normal
     ) -> Self {
         self.reactive.titleColor(for: state) <~ color.producer
@@ -57,7 +57,7 @@ extension UIButton {
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
     public func title(
-        color: any SignalProducerConvertible<UIColor, Never>,
+        color: some SignalProducerConvertible<UIColor, Never>,
         state: UIControl.State = .normal
     ) -> Self {
         self.reactive.titleColor(for: state) <~ color.producer
@@ -91,7 +91,7 @@ extension UIButton {
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
     public func title(
-        _ title: any SignalProducerConvertible<String, Never>,
+        _ title: some SignalProducerConvertible<String, Never>,
         for state: UIControl.State = .normal
     ) -> Self {
         self.reactive.title(for: state) <~ title.producer
@@ -105,7 +105,7 @@ extension UIButton {
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
     public func image(
-        _ image: any SignalProducerConvertible<UIImage, Never>,
+        _ image: some SignalProducerConvertible<UIImage, Never>,
         for state: UIControl.State = .normal
     ) -> Self {
         self.reactive.image(for: state) <~ image.producer
@@ -117,7 +117,7 @@ extension UIButton {
     /// - returns: The button
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
-    public func font(_ font: any SignalProducerConvertible<UIFont, Never>) -> Self {
+    public func font(_ font: some SignalProducerConvertible<UIFont, Never>) -> Self {
         _ = self.titleLabel?.font(font)
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIButton.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIButton.swift
@@ -42,8 +42,11 @@ extension UIButton {
     /// - returns: The button
     /// - note: **Mutating modifier** modifies a property of the button
     @discardableResult
-    public func title<T: SignalProducerConvertible>(color: T, state: UIControl.State = .normal) -> Self where T.Value == UIColor? {
-        self.reactive.titleColor(for: state) <~ color.producer.eraseError()
+    public func title(
+        color: any SignalProducerConvertible<UIColor?, Never>,
+        state: UIControl.State = .normal
+    ) -> Self {
+        self.reactive.titleColor(for: state) <~ color.producer
         return self
     }
     
@@ -53,8 +56,11 @@ extension UIButton {
     /// - returns: The button
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
-    public func title<T: SignalProducerConvertible>(color: T, state: UIControl.State = .normal) -> Self where T.Value == UIColor {
-        self.reactive.titleColor(for: state) <~ color.producer.eraseError()
+    public func title(
+        color: any SignalProducerConvertible<UIColor, Never>,
+        state: UIControl.State = .normal
+    ) -> Self {
+        self.reactive.titleColor(for: state) <~ color.producer
         return self
     }
     
@@ -84,8 +90,11 @@ extension UIButton {
     /// - returns: The button
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
-    public func title<T: SignalProducerConvertible>(_ title: T, for state: UIControl.State = .normal) -> Self where T.Value == String {
-        self.reactive.title(for: state) <~ title.producer.eraseError()
+    public func title(
+        _ title: any SignalProducerConvertible<String, Never>,
+        for state: UIControl.State = .normal
+    ) -> Self {
+        self.reactive.title(for: state) <~ title.producer
         return self
     }
     
@@ -95,8 +104,11 @@ extension UIButton {
     /// - returns: The button
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
-    public func image<T: SignalProducerConvertible>(_ image: T, for state: UIControl.State = .normal) -> Self where T.Value == UIImage {
-        self.reactive.image(for: state) <~ image.producer.eraseError()
+    public func image(
+        _ image: any SignalProducerConvertible<UIImage, Never>,
+        for state: UIControl.State = .normal
+    ) -> Self {
+        self.reactive.image(for: state) <~ image.producer
         return self
     }
     
@@ -105,7 +117,7 @@ extension UIButton {
     /// - returns: The button
     /// - note: **Mutating modifier** modifies a property of the `UIButton`
     @discardableResult
-    public func font<T: SignalProducerConvertible>(_ font: T) -> Self where T.Value == UIFont {
+    public func font(_ font: any SignalProducerConvertible<UIFont, Never>) -> Self {
         _ = self.titleLabel?.font(font)
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIControl.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIControl.swift
@@ -33,7 +33,7 @@ extension UIControl {
     /// - parameter isSelected: Property<Bool> with the state to set for the button
     /// - returns: The `UIControl` object
     /// - note: **Mutating modifier** modifies a property of the `UIControl`
-    public func isSelected(_ isSelected: any SignalProducerConvertible<Bool, Never>) -> Self {
+    public func isSelected(_ isSelected: some SignalProducerConvertible<Bool, Never>) -> Self {
         self.reactive.isSelected <~ isSelected.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIControl.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIControl.swift
@@ -33,8 +33,8 @@ extension UIControl {
     /// - parameter isSelected: Property<Bool> with the state to set for the button
     /// - returns: The `UIControl` object
     /// - note: **Mutating modifier** modifies a property of the `UIControl`
-    public func isSelected<T: SignalProducerConvertible>(_ isSelected: T) -> Self where T.Value == Bool {
-        self.reactive.isSelected <~ isSelected.producer.eraseError()
+    public func isSelected(_ isSelected: any SignalProducerConvertible<Bool, Never>) -> Self {
+        self.reactive.isSelected <~ isSelected.producer
         return self
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UIImageView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIImageView.swift
@@ -27,7 +27,7 @@ extension UIImageView {
     /// - parameter contentMode: The content mode to use
     /// - returns: An `UIImageView` with the specified image and content mode
     public convenience init(
-        image: any SignalProducerConvertible<UIImage?, Never>,
+        image: some SignalProducerConvertible<UIImage?, Never>,
         contentMode: UIImageView.ContentMode = .scaleAspectFit
     ) {
         self.init(image: nil, contentMode: contentMode)
@@ -72,7 +72,7 @@ extension UIImageView {
     /// - parameter contentMode: Stream of `UIImageView.ContentMode` The content mode to use for the image view
     /// - returns: The `UIImageView`
     /// - note: **Mutating modifier** modifies a property of the `UIImageView`
-    public func contentMode(_ mode: any SignalProducerConvertible<UIView.ContentMode, Never>) -> Self {
+    public func contentMode(_ mode: some SignalProducerConvertible<UIView.ContentMode, Never>) -> Self {
         self.reactive.contentMode <~ mode.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIImageView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIImageView.swift
@@ -26,9 +26,12 @@ extension UIImageView {
     /// - parameter image: The image producer to use
     /// - parameter contentMode: The content mode to use
     /// - returns: An `UIImageView` with the specified image and content mode
-    public convenience init<T: SignalProducerConvertible>(image: T, contentMode: UIImageView.ContentMode = .scaleAspectFit) where T.Value == UIImage? {
+    public convenience init(
+        image: any SignalProducerConvertible<UIImage?, Never>,
+        contentMode: UIImageView.ContentMode = .scaleAspectFit
+    ) {
         self.init(image: nil, contentMode: contentMode)
-        self.reactive.image <~ image.producer.eraseError()
+        self.reactive.image <~ image.producer
     }
     
     /// Forces the image view to maintain the same aspect ratio as the `UIImage` class it contains
@@ -69,8 +72,8 @@ extension UIImageView {
     /// - parameter contentMode: Stream of `UIImageView.ContentMode` The content mode to use for the image view
     /// - returns: The `UIImageView`
     /// - note: **Mutating modifier** modifies a property of the `UIImageView`
-    public func contentMode<T: SignalProducerConvertible>(_ mode: T) -> Self where T.Value == UIView.ContentMode {
-        self.reactive.contentMode <~ mode.producer.eraseError()
+    public func contentMode(_ mode: any SignalProducerConvertible<UIView.ContentMode, Never>) -> Self {
+        self.reactive.contentMode <~ mode.producer
         return self
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UILabel.swift
+++ b/Sources/KitUI/Extensions/UIKit/UILabel.swift
@@ -15,7 +15,7 @@ extension UILabel {
     /// - returns: A `UILabel` bound to the specified stream
     /// - note: Sets the `numberOfLines` to `0` to allow for multiline text
     public convenience init(
-        _ text: any SignalProducerConvertible<any Stringish, Never>
+        _ text: any SignalProducerConvertible<String?, Never>
     ) {
         self.init()
         self.numberOfLines = 0
@@ -70,7 +70,7 @@ extension UILabel {
     /// - parameter text: `String?` The text to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func text(_ text: any SignalProducerConvertible<any Stringish, Never>) -> Self {
+    public func text(_ text: any SignalProducerConvertible<String?, Never>) -> Self {
         self.reactive.text <~ text.producer.map(\.stringValue)
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UILabel.swift
+++ b/Sources/KitUI/Extensions/UIKit/UILabel.swift
@@ -15,7 +15,7 @@ extension UILabel {
     /// - returns: A `UILabel` bound to the specified stream
     /// - note: Sets the `numberOfLines` to `0` to allow for multiline text
     public convenience init(
-        _ text: any SignalProducerConvertible<String?, Never>
+        _ text: some SignalProducerConvertible<String?, Never>
     ) {
         self.init()
         self.numberOfLines = 0
@@ -28,7 +28,7 @@ extension UILabel {
     /// - returns: A `UILabel` bound to the specified stream
     /// - note: Sets the `numberOfLines` to `0` to allow for multiline text
     public convenience init(
-        _ text: any SignalProducerConvertible<String, Never>
+        _ text: some SignalProducerConvertible<String, Never>
     ) {
         self.init(text.producer.map { $0 as String? })
     }
@@ -37,7 +37,7 @@ extension UILabel {
     /// - parameter text: The attributed text producer to use for the label
     /// - returns: A `UILabel` with the specified attributed text
     public convenience init(
-        _ text: any SignalProducerConvertible<NSAttributedString, Never>
+        _ text: some SignalProducerConvertible<NSAttributedString, Never>
     ) {
         self.init()
         self.numberOfLines = 0
@@ -52,7 +52,7 @@ extension UILabel {
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
     public func font(
-        _ font: any SignalProducerConvertible<UIFont?, Never>,
+        _ font: some SignalProducerConvertible<UIFont?, Never>,
         scale: Bool = true,
         relativeTo style: UIFont.TextStyle? = nil
     ) -> Self {
@@ -68,7 +68,7 @@ extension UILabel {
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
     public func font(
-        _ font: any SignalProducerConvertible<UIFont, Never>,
+        _ font: some SignalProducerConvertible<UIFont, Never>,
         scale: Bool = true,
         relativeTo style: UIFont.TextStyle? = nil
     ) -> Self {
@@ -80,7 +80,7 @@ extension UILabel {
     /// - parameter text: `String?` The text to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func text(_ text: any SignalProducerConvertible<String?, Never>) -> Self {
+    public func text(_ text: some SignalProducerConvertible<String?, Never>) -> Self {
         self.reactive.text <~ text.producer.map(\.stringValue)
         return self
     }
@@ -89,7 +89,7 @@ extension UILabel {
     /// - parameter color: `UIColor` The color to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func color(_ color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+    public func color(_ color: some SignalProducerConvertible<UIColor, Never>) -> Self {
         self.reactive.textColor <~ color.producer
         return self
     }
@@ -98,7 +98,7 @@ extension UILabel {
     /// - parameter alignment: `NSTextAlignment` The alignment to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func alignment(_ alignment: any SignalProducerConvertible<NSTextAlignment, Never>) -> Self {
+    public func alignment(_ alignment: some SignalProducerConvertible<NSTextAlignment, Never>) -> Self {
         self.reactive.textAlignment <~ alignment.producer
         return self
     }
@@ -107,7 +107,7 @@ extension UILabel {
     /// - parameter lines: `Int` The number of lines to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func numberOfLines(_ number: any SignalProducerConvertible<Int, Never>) -> Self {
+    public func numberOfLines(_ number: some SignalProducerConvertible<Int, Never>) -> Self {
         self.reactive.numberOfLines <~ number.producer
         return self
     }
@@ -120,7 +120,7 @@ extension UILabel {
     /// allows consumers to run a complicated string generation inline? Might toss
     /// this eventually?
     public func attributedText(
-        _ block: () -> any SignalProducerConvertible<NSAttributedString, Never>
+        _ block: () -> some SignalProducerConvertible<NSAttributedString, Never>
     ) -> Self {
         let text = block()
         self.reactive.attributedText <~ text.producer
@@ -131,7 +131,7 @@ extension UILabel {
     /// - parameter text: `SignalProducerConvertiable<NSAttributedString>` The attributed text to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func attributedText(_ value: any SignalProducerConvertible<NSAttributedString, Never>) -> Self {
+    public func attributedText(_ value: some SignalProducerConvertible<NSAttributedString, Never>) -> Self {
         self.reactive.attributedText <~ value.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UILabel.swift
+++ b/Sources/KitUI/Extensions/UIKit/UILabel.swift
@@ -14,30 +14,21 @@ extension UILabel {
     /// - parameter text: The `String` stream of values to bind to the `UILabel`
     /// - returns: A `UILabel` bound to the specified stream
     /// - note: Sets the `numberOfLines` to `0` to allow for multiline text
-    public convenience init<T: SignalProducerConvertible>(
-        _ text: T
-    ) where T.Value == String {
+    public convenience init(
+        _ text: any SignalProducerConvertible<any Stringish, Never>
+    ) {
         self.init()
         self.numberOfLines = 0
         self.adjustsFontForContentSizeCategory = true
         _ = self.text(text)
     }
     
-    /// Initialize a label with a `String?` producer
-    /// - parameter text: The `String?` producer to use for the label
-    /// - returns: A `UILabel` with the specified text
-    public convenience init<T: SignalProducerConvertible>(
-        _ text: T
-    ) where T.Value == String? {
-        self.init(text.producer.map { $0 ?? ""})
-    }
-    
     /// Intialize a label with an attributed text producer
     /// - parameter text: The attributed text producer to use for the label
     /// - returns: A `UILabel` with the specified attributed text
-    public convenience init<T: SignalProducerConvertible>(
-        _ text: T
-    ) where T.Value == NSAttributedString {
+    public convenience init(
+        _ text: any SignalProducerConvertible<NSAttributedString, Never>
+    ) {
         self.init()
         self.numberOfLines = 0
         _ = self.attributedText(text)
@@ -50,8 +41,12 @@ extension UILabel {
     ///   the `UIFontMetrics.default`
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func font<T: SignalProducerConvertible>(_ font: T, scale: Bool = true, relativeTo style: UIFont.TextStyle? = nil) -> Self where T.Value == UIFont? {
-        self.reactive.font <~ font.producer.eraseError().map { scale ? $0?.scaled(withStyle: style) : $0 }
+    public func font(
+        _ font: any SignalProducerConvertible<UIFont?, Never>,
+        scale: Bool = true,
+        relativeTo style: UIFont.TextStyle? = nil
+    ) -> Self {
+        self.reactive.font <~ font.producer.map { scale ? $0?.scaled(withStyle: style) : $0 }
         return self
     }
     
@@ -62,8 +57,12 @@ extension UILabel {
     ///   the `UIFontMetrics.default`
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func font<T: SignalProducerConvertible>(_ font: T, scale: Bool = true, relativeTo style: UIFont.TextStyle? = nil) -> Self where T.Value == UIFont {
-        self.reactive.font <~ font.producer.eraseError().map { scale ? $0.scaled(withStyle: style) : $0 }
+    public func font(
+        _ font: any SignalProducerConvertible<UIFont, Never>,
+        scale: Bool = true,
+        relativeTo style: UIFont.TextStyle? = nil
+    ) -> Self {
+        self.reactive.font <~ font.producer.map { scale ? $0.scaled(withStyle: style) : $0 }
         return self
     }
     
@@ -71,17 +70,8 @@ extension UILabel {
     /// - parameter text: `String?` The text to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func text<T: SignalProducerConvertible>(_ text: T) -> Self where T.Value == String? {
-        self.reactive.text <~ text.producer.eraseError()
-        return self
-    }
-    
-    /// Chainable Method for setting the text of the label
-    /// - parameter text: `String` The text to use for the label
-    /// - returns: The `UILabel`
-    /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func text<T: SignalProducerConvertible>(_ text: T) -> Self where T.Value == String {
-        self.reactive.text <~ text.producer.eraseError()
+    public func text(_ text: any SignalProducerConvertible<any Stringish, Never>) -> Self {
+        self.reactive.text <~ text.producer.map(\.stringValue)
         return self
     }
     
@@ -89,8 +79,8 @@ extension UILabel {
     /// - parameter color: `UIColor` The color to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func color<T: SignalProducerConvertible>(_ color: T) -> Self where T.Value == UIColor {
-        self.reactive.textColor <~ color.producer.eraseError()
+    public func color(_ color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+        self.reactive.textColor <~ color.producer
         return self
     }
     
@@ -98,8 +88,8 @@ extension UILabel {
     /// - parameter alignment: `NSTextAlignment` The alignment to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func alignment<T: SignalProducerConvertible>(_ alignment: T) -> Self where T.Value == NSTextAlignment {
-        self.reactive.textAlignment <~ alignment.producer.eraseError()
+    public func alignment(_ alignment: any SignalProducerConvertible<NSTextAlignment, Never>) -> Self {
+        self.reactive.textAlignment <~ alignment.producer
         return self
     }
     
@@ -107,8 +97,8 @@ extension UILabel {
     /// - parameter lines: `Int` The number of lines to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func numberOfLines<T: SignalProducerConvertible>(_ number: T) -> Self where T.Value == Int {
-        self.reactive.numberOfLines <~ number.producer.eraseError()
+    public func numberOfLines(_ number: any SignalProducerConvertible<Int, Never>) -> Self {
+        self.reactive.numberOfLines <~ number.producer
         return self
     }
     
@@ -119,9 +109,11 @@ extension UILabel {
     /// - note: A bit of an experiment, but allowing this closure based version of the method
     /// allows consumers to run a complicated string generation inline? Might toss
     /// this eventually?
-    public func attributedText<T: SignalProducerConvertible>(_ block: () -> T) -> Self where T.Value == NSAttributedString {
+    public func attributedText(
+        _ block: () -> any SignalProducerConvertible<NSAttributedString, Never>
+    ) -> Self {
         let text = block()
-        self.reactive.attributedText <~ text.producer.eraseError()
+        self.reactive.attributedText <~ text.producer
         return self
     }
     
@@ -129,8 +121,8 @@ extension UILabel {
     /// - parameter text: `SignalProducerConvertiable<NSAttributedString>` The attributed text to use for the label
     /// - returns: The `UILabel`
     /// - note: **Mutating modifier** modifies a property of the `UILabel`
-    public func attributedText<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == NSAttributedString {
-        self.reactive.attributedText <~ value.producer.eraseError()
+    public func attributedText(_ value: any SignalProducerConvertible<NSAttributedString, Never>) -> Self {
+        self.reactive.attributedText <~ value.producer
         return self
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UILabel.swift
+++ b/Sources/KitUI/Extensions/UIKit/UILabel.swift
@@ -23,6 +23,16 @@ extension UILabel {
         _ = self.text(text)
     }
     
+    /// Initialize a `UILabel` with a reactive `String` value
+    /// - parameter text: The `String` stream of values to bind to the `UILabel`
+    /// - returns: A `UILabel` bound to the specified stream
+    /// - note: Sets the `numberOfLines` to `0` to allow for multiline text
+    public convenience init(
+        _ text: any SignalProducerConvertible<String, Never>
+    ) {
+        self.init(text.producer.map { $0 as String? })
+    }
+    
     /// Intialize a label with an attributed text producer
     /// - parameter text: The attributed text producer to use for the label
     /// - returns: A `UILabel` with the specified attributed text

--- a/Sources/KitUI/Extensions/UIKit/UIStackView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIStackView.swift
@@ -39,7 +39,7 @@ extension UIStackView {
         axis: any SignalProducerConvertible<NSLayoutConstraint.Axis, Never> = NSLayoutConstraint.Axis.vertical,
         distribution: any SignalProducerConvertible<UIStackView.Distribution, Never> = UIStackView.Distribution.fill,
         alignment: any SignalProducerConvertible<UIStackView.Alignment, Never> = UIStackView.Alignment.fill,
-        spacing: any SignalProducerConvertible<any CGFloatable, Never> = SignalProducer<CGFloatable, Never>(value: 0),
+        spacing: any SignalProducerConvertible<CGFloat, Never> = SignalProducer<CGFloat, Never>(value: 0),
         @UIViewBuilder builder: () -> [UIView]
     ) {
         self.init(frame: .zero)
@@ -79,7 +79,7 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func spacing(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
+    public func spacing(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
         self.reactive.spacing <~ value.producer.map(\.cgFloat)
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIStackView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIStackView.swift
@@ -36,10 +36,10 @@ extension UIStackView {
     /// Initialize a stack view with the specified properties
     /// - note: Prefer using chainable methods rather than this initializer
     public convenience init(
-        axis: any SignalProducerConvertible<NSLayoutConstraint.Axis, Never> = NSLayoutConstraint.Axis.vertical,
-        distribution: any SignalProducerConvertible<UIStackView.Distribution, Never> = UIStackView.Distribution.fill,
-        alignment: any SignalProducerConvertible<UIStackView.Alignment, Never> = UIStackView.Alignment.fill,
-        spacing: any SignalProducerConvertible<CGFloat, Never> = SignalProducer<CGFloat, Never>(value: 0),
+        axis: some SignalProducerConvertible<NSLayoutConstraint.Axis, Never> = NSLayoutConstraint.Axis.vertical,
+        distribution: some SignalProducerConvertible<UIStackView.Distribution, Never> = UIStackView.Distribution.fill,
+        alignment: some SignalProducerConvertible<UIStackView.Alignment, Never> = UIStackView.Alignment.fill,
+        spacing: some SignalProducerConvertible<CGFloat, Never> = SignalProducer<CGFloat, Never>(value: 0),
         @UIViewBuilder builder: () -> [UIView]
     ) {
         self.init(frame: .zero)
@@ -69,7 +69,7 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func axis(_ axis: any SignalProducerConvertible<NSLayoutConstraint.Axis, Never>) -> Self {
+    public func axis(_ axis: some SignalProducerConvertible<NSLayoutConstraint.Axis, Never>) -> Self {
         self.reactive.axis <~ axis.producer
         return self
     }
@@ -79,7 +79,7 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func spacing(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
+    public func spacing(_ value: some SignalProducerConvertible<Double, Never>) -> Self {
         self.reactive.spacing <~ value.producer.map(\.cgFloat)
         return self
     }
@@ -89,7 +89,7 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func distribution(_ value: any SignalProducerConvertible<UIStackView.Distribution, Never>) -> Self {
+    public func distribution(_ value: some SignalProducerConvertible<UIStackView.Distribution, Never>) -> Self {
         self.reactive.distribution <~ value.producer
         return self
     }
@@ -99,7 +99,7 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func alignment(_ value: any SignalProducerConvertible<UIStackView.Alignment, Never>) -> Self {
+    public func alignment(_ value: some SignalProducerConvertible<UIStackView.Alignment, Never>) -> Self {
         self.reactive.alignment <~ value.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIStackView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIStackView.swift
@@ -35,27 +35,18 @@ extension UIStackView {
     
     /// Initialize a stack view with the specified properties
     /// - note: Prefer using chainable methods rather than this initializer
-    public convenience init<
-        T: SignalProducerConvertible,
-        U: SignalProducerConvertible,
-        V: SignalProducerConvertible,
-        X: SignalProducerConvertible
-    >(
-        axis: T = NSLayoutConstraint.Axis.vertical as! T,
-        distribution: U = UIStackView.Distribution.fill as! U,
-        alignment: V = UIStackView.Alignment.fill as! V,
-        spacing: X = CGFloat(0.0) as! X,
+    public convenience init(
+        axis: any SignalProducerConvertible<NSLayoutConstraint.Axis, Never> = NSLayoutConstraint.Axis.vertical,
+        distribution: any SignalProducerConvertible<UIStackView.Distribution, Never> = UIStackView.Distribution.fill,
+        alignment: any SignalProducerConvertible<UIStackView.Alignment, Never> = UIStackView.Alignment.fill,
+        spacing: any SignalProducerConvertible<any CGFloatable, Never> = SignalProducer<CGFloatable, Never>(value: 0),
         @UIViewBuilder builder: () -> [UIView]
-    ) where T.Value == NSLayoutConstraint.Axis,
-    U.Value == UIStackView.Distribution,
-    V.Value == UIStackView.Alignment,
-    X.Value == CGFloat
-    {
+    ) {
         self.init(frame: .zero)
-        self.reactive.axis <~ axis.producer.eraseError()
-        self.reactive.distribution <~ distribution.producer.eraseError()
-        self.reactive.alignment <~ alignment.producer.eraseError()
-        self.reactive.spacing <~ spacing.producer.eraseError()
+        self.reactive.axis <~ axis.producer
+        self.reactive.distribution <~ distribution.producer
+        self.reactive.alignment <~ alignment.producer
+        self.reactive.spacing <~ spacing.producer.map(\.cgFloat)
         self.isUserInteractionEnabled = true
         self.setHugging(.init(rawValue: 751), for: .vertical)
         self.setHugging(.init(rawValue: 751), for: .horizontal)
@@ -78,8 +69,8 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func axis<T: SignalProducerConvertible>(_ axis: T) -> Self where T.Value == NSLayoutConstraint.Axis {
-        self.reactive.axis <~ axis.producer.eraseError()
+    public func axis(_ axis: any SignalProducerConvertible<NSLayoutConstraint.Axis, Never>) -> Self {
+        self.reactive.axis <~ axis.producer
         return self
     }
     
@@ -88,8 +79,8 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func spacing<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == Double {
-        self.reactive.spacing <~ value.producer.map { CGFloat($0) }.eraseError()
+    public func spacing(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
+        self.reactive.spacing <~ value.producer.map(\.cgFloat)
         return self
     }
     
@@ -98,8 +89,8 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func distribution<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == UIStackView.Distribution {
-        self.reactive.distribution <~ value.producer.eraseError()
+    public func distribution(_ value: any SignalProducerConvertible<UIStackView.Distribution, Never>) -> Self {
+        self.reactive.distribution <~ value.producer
         return self
     }
     
@@ -108,8 +99,8 @@ extension UIStackView {
     /// - returns self
     /// - note: **Mutating Modifier** modifies a property of the `UIStackView`
     @discardableResult
-    public func alignment<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == UIStackView.Alignment {
-        self.reactive.alignment <~ value.producer.eraseError()
+    public func alignment(_ value: any SignalProducerConvertible<UIStackView.Alignment, Never>) -> Self {
+        self.reactive.alignment <~ value.producer
         return self
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UISwitch.swift
+++ b/Sources/KitUI/Extensions/UIKit/UISwitch.swift
@@ -27,7 +27,7 @@ extension UISwitch {
     /// - parameter color: reactive `UIColor` stream of colors to use for the `onTintColor` of the switch
     /// - returns: The `UISwitch`
     /// - note: **Mutating modifier** modifies a property of the `UISwitch` 
-    public func onTint(color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+    public func onTint(color: some SignalProducerConvertible<UIColor, Never>) -> Self {
         self.reactive.onTintColor <~ color.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UISwitch.swift
+++ b/Sources/KitUI/Extensions/UIKit/UISwitch.swift
@@ -27,8 +27,8 @@ extension UISwitch {
     /// - parameter color: reactive `UIColor` stream of colors to use for the `onTintColor` of the switch
     /// - returns: The `UISwitch`
     /// - note: **Mutating modifier** modifies a property of the `UISwitch` 
-    public func onTint<T: SignalProducerConvertible>(color: T) -> Self where T.Value == UIColor {
-        self.reactive.onTintColor <~ color.producer.eraseError()
+    public func onTint(color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+        self.reactive.onTintColor <~ color.producer
         return self
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UITableView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UITableView.swift
@@ -16,7 +16,7 @@ extension UITableView {
     /// Reactively updates the dragInteractionEnabled state of the table view.
     /// - parameter dragInteractionEnabled: A `SignalProducerConvertible` which will update the dragInteractionEnabled state of the table view.
     /// - returns: The `UITableView` it's called on.
-    public func dragInteractionEnabled(_ enabled: any SignalProducerConvertible<Bool, Never>) -> Self {
+    public func dragInteractionEnabled(_ enabled: some SignalProducerConvertible<Bool, Never>) -> Self {
         self.reactive.dragInteractionEnabled <~ enabled.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UITableView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UITableView.swift
@@ -16,8 +16,8 @@ extension UITableView {
     /// Reactively updates the dragInteractionEnabled state of the table view.
     /// - parameter dragInteractionEnabled: A `SignalProducerConvertible` which will update the dragInteractionEnabled state of the table view.
     /// - returns: The `UITableView` it's called on.
-    public func dragInteractionEnabled<T: SignalProducerConvertible>(_ enabled: T) -> Self where T.Value == Bool {
-        self.reactive.dragInteractionEnabled <~ enabled.producer.eraseError()
+    public func dragInteractionEnabled(_ enabled: any SignalProducerConvertible<Bool, Never>) -> Self {
+        self.reactive.dragInteractionEnabled <~ enabled.producer
         return self
     }
     

--- a/Sources/KitUI/Extensions/UIKit/UITextField.swift
+++ b/Sources/KitUI/Extensions/UIKit/UITextField.swift
@@ -15,7 +15,7 @@ extension UITextField {
     /// - parameter text: The stream of values to send to the text of the textField
     /// - returns: The `UITextField` it's called on
     /// - note: **Modifies the `UITextField`**
-    public func text(_ text: any SignalProducerConvertible<String?, Never>) -> Self {
+    public func text(_ text: some SignalProducerConvertible<String?, Never>) -> Self {
         self.reactive.text <~ text.producer
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UITextField.swift
+++ b/Sources/KitUI/Extensions/UIKit/UITextField.swift
@@ -15,8 +15,8 @@ extension UITextField {
     /// - parameter text: The stream of values to send to the text of the textField
     /// - returns: The `UITextField` it's called on
     /// - note: **Modifies the `UITextField`**
-    public func text(_ text: any SignalProducerConvertible<any Stringish, Never>) -> Self {
-        self.reactive.text <~ text.producer.map(\.stringValue)
+    public func text(_ text: any SignalProducerConvertible<String?, Never>) -> Self {
+        self.reactive.text <~ text.producer
         return self
     }
     

--- a/Sources/KitUI/Extensions/UIKit/UITextField.swift
+++ b/Sources/KitUI/Extensions/UIKit/UITextField.swift
@@ -15,8 +15,8 @@ extension UITextField {
     /// - parameter text: The stream of values to send to the text of the textField
     /// - returns: The `UITextField` it's called on
     /// - note: **Modifies the `UITextField`**
-    public func text<T: SignalProducerConvertible>(_ text: T) -> Self where T.Value: Stringish {
-        self.reactive.text <~ text.producer.map(\.stringValue).eraseError()
+    public func text(_ text: any SignalProducerConvertible<any Stringish, Never>) -> Self {
+        self.reactive.text <~ text.producer.map(\.stringValue)
         return self
     }
     

--- a/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
@@ -14,10 +14,10 @@ extension UIView {
     /// - parameter hideShadow
     /// - returns A `UIView` with the specified shadow
     /// - note: This currently supplies a default shadow color, opacity, offset, and radius
-    public func shadow<T: SignalProducerConvertible>(
+    public func shadow(
         cornerRadius: Int = 0,
-        hideShadow: T = Property<Bool>.constant(false)
-    ) -> UIView where T.Value == Bool {
+        hideShadow: any SignalProducerConvertible<Bool, Never> = false
+    ) -> UIView {
         let shadow = UIView()
         shadow.layer.shadowColor = UIColor.black.cgColor
         shadow.layer.shadowOffset = .init(width: 0, height: 1)
@@ -26,7 +26,7 @@ extension UIView {
         shadow.layer.cornerRadius = .init(cornerRadius)
         
         shadow.addSubview(self)
-        self.cornerRadius(cornerRadius)
+        self.cornerRadius(cornerRadius.producer.map { $0 as CGFloatable })
         self.edgesToSuperview()
         return shadow
     }

--- a/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
@@ -26,7 +26,7 @@ extension UIView {
         shadow.layer.cornerRadius = .init(cornerRadius)
         
         shadow.addSubview(self)
-        self.cornerRadius(CGFloat(cornerRadius))
+        self.cornerRadius(Double(cornerRadius))
         self.edgesToSuperview()
         return shadow
     }

--- a/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
@@ -16,7 +16,7 @@ extension UIView {
     /// - note: This currently supplies a default shadow color, opacity, offset, and radius
     public func shadow(
         cornerRadius: Int = 0,
-        hideShadow: any SignalProducerConvertible<Bool, Never> = false
+        hideShadow: some SignalProducerConvertible<Bool, Never> = false
     ) -> UIView {
         let shadow = UIView()
         shadow.layer.shadowColor = UIColor.black.cgColor

--- a/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView+Shadow.swift
@@ -26,7 +26,7 @@ extension UIView {
         shadow.layer.cornerRadius = .init(cornerRadius)
         
         shadow.addSubview(self)
-        self.cornerRadius(cornerRadius.producer.map { $0 as CGFloatable })
+        self.cornerRadius(CGFloat(cornerRadius))
         self.edgesToSuperview()
         return shadow
     }

--- a/Sources/KitUI/Extensions/UIKit/UIView+Wrap.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView+Wrap.swift
@@ -103,7 +103,7 @@ extension UIView {
     /// - parameter view: A closure which returns the view to add as a child
     /// - returns: A new `UIView` with the specified configuration
     public static func wrap(
-        configuration: any SignalProducerConvertible<WrapConfiguration, Never>,
+        configuration: some SignalProducerConvertible<WrapConfiguration, Never>,
         _ view: () -> UIView
     ) -> UIView {
         let child = view()

--- a/Sources/KitUI/Extensions/UIKit/UIView+Wrap.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView+Wrap.swift
@@ -102,14 +102,17 @@ extension UIView {
     ///   the child view's wrap configuration reactively
     /// - parameter view: A closure which returns the view to add as a child
     /// - returns: A new `UIView` with the specified configuration
-    public static func wrap<T: SignalProducerConvertible>(configuration: T, _ view: () -> UIView) -> UIView where T.Value == WrapConfiguration {
+    public static func wrap(
+        configuration: any SignalProducerConvertible<WrapConfiguration, Never>,
+        _ view: () -> UIView
+    ) -> UIView {
         let child = view()
         let view = UIView()
         view.addSubview(child)
         
         var constraints: Constraints?
         
-        configuration.producer.eraseError().startWithValues { config in
+        configuration.producer.startWithValues { config in
             constraints?.deActivate()
             constraints = UIView.setupConstraints(
                 child: child,

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -59,7 +59,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func tint(_ color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+    public func tint(_ color: some SignalProducerConvertible<UIColor, Never>) -> Self {
         self.reactive.tintColor <~ color.producer
         return self
     }
@@ -69,7 +69,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func border(_ border: any SignalProducerConvertible<BorderStyle, Never>) -> Self {
+    public func border(_ border: some SignalProducerConvertible<BorderStyle, Never>) -> Self {
         self.layer.reactive.border <~ border.producer
         return self
     }
@@ -81,7 +81,7 @@ extension UIView {
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
     public func cornerRadius(
-        _ value: any SignalProducerConvertible<Double, Never>,
+        _ value: some SignalProducerConvertible<Double, Never>,
         corners: CACornerMask = .all
     ) -> Self{
         self.clipsToBounds = true
@@ -95,7 +95,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func backgroundColor(_ value: any SignalProducerConvertible<UIColor, Never>) -> Self {
+    public func backgroundColor(_ value: some SignalProducerConvertible<UIColor, Never>) -> Self {
         self.reactive.backgroundColor <~ value.producer
         return self
     }
@@ -118,7 +118,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func transform(_ value: any SignalProducerConvertible<CGAffineTransform, Never>) -> Self {
+    public func transform(_ value: some SignalProducerConvertible<CGAffineTransform, Never>) -> Self {
         value.producer
             .take(duringLifetimeOf: self)
             .observe(on: QueueScheduler.main)
@@ -132,7 +132,7 @@ extension UIView {
     /// - parameter hidden: A reactive value with a boolean to set as the hidden state
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func hidden(_ value: any SignalProducerConvertible<Bool, Never>) -> Self {
+    public func hidden(_ value: some SignalProducerConvertible<Bool, Never>) -> Self {
         self.reactive.isHidden <~ value.producer
         return self
     }
@@ -141,7 +141,7 @@ extension UIView {
     /// - parameter alpha: A reactive value with a float to set as the alpha
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func alpha(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
+    public func alpha(_ value: some SignalProducerConvertible<Double, Never>) -> Self {
         self.reactive.alpha <~ value.producer.map(\.cgFloat)
         return self
     }
@@ -150,7 +150,7 @@ extension UIView {
     /// - parameter value: A reactive value with a boolean to set as the isUserInteractionEnabled
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func userInteractionEnabled(_ value: any SignalProducerConvertible<Bool, Never>) -> Self {
+    public func userInteractionEnabled(_ value: some SignalProducerConvertible<Bool, Never>) -> Self {
         self.reactive.isUserInteractionEnabled <~ value.producer
         return self
     }
@@ -184,7 +184,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func height(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
+    public func height(_ value: some SignalProducerConvertible<Double, Never>) -> Self {
         let constraint: Constraint = self.height(0)
         constraint.reactive.constant <~ value.producer.map(\.cgFloat)
         return self
@@ -195,7 +195,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func width(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
+    public func width(_ value: some SignalProducerConvertible<Double, Never>) -> Self {
         let constraint: Constraint = self.width(0)
         constraint.reactive.constant <~ value.producer.map(\.cgFloat)
         return self
@@ -206,7 +206,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func size(_ size: any SignalProducerConvertible<Double, Never>) -> Self {
+    public func size(_ size: some SignalProducerConvertible<Double, Never>) -> Self {
         self
             .width(size)
             .height(size)
@@ -217,7 +217,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies the state of the current view
     @discardableResult
-    public func aspectRatio(_ ratio: any SignalProducerConvertible<Double, Never>) -> Self {
+    public func aspectRatio(_ ratio: some SignalProducerConvertible<Double, Never>) -> Self {
         var constraint: Constraint?
         ratio.producer.take(duringLifetimeOf: self).startWithValues { [weak self] multiplier in
             constraint?.isActive = false
@@ -231,7 +231,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func size(_ size: any SignalProducerConvertible<CGSize, Never>) -> Self {
+    public func size(_ size: some SignalProducerConvertible<CGSize, Never>) -> Self {
         
         self.height(size.producer.map(\.height).map(Double.init))
             .width(size.producer.map(\.width).map(Double.init))
@@ -244,7 +244,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityLabel(_ value: any SignalProducerConvertible<String, Never>) -> Self {
+    public func accessibilityLabel(_ value: some SignalProducerConvertible<String, Never>) -> Self {
         self.reactive.accessibilityLabel <~ value.producer
         return self
     }
@@ -254,7 +254,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityHint(_ value: any SignalProducerConvertible<String, Never>) -> Self  {
+    public func accessibilityHint(_ value: some SignalProducerConvertible<String, Never>) -> Self  {
         self.reactive.accessibilityHint <~ value.producer
         return self
     }
@@ -264,7 +264,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityValue(_ value: any SignalProducerConvertible<String, Never>) -> Self {
+    public func accessibilityValue(_ value: some SignalProducerConvertible<String, Never>) -> Self {
         value.producer.take(duringLifetimeOf: self).startWithValues { [weak self] text in
             self?.accessibilityValue = text
         }
@@ -276,7 +276,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityTraits(_ traits: any SignalProducerConvertible<UIAccessibilityTraits, Never>) -> Self {
+    public func accessibilityTraits(_ traits: some SignalProducerConvertible<UIAccessibilityTraits, Never>) -> Self {
         traits.producer.take(duringLifetimeOf: self).startWithValues { [weak self] traits in
             self?.accessibilityTraits = traits
         }
@@ -288,7 +288,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func isAccessibilityElement(_ value: any SignalProducerConvertible<Bool, Never>) -> Self {
+    public func isAccessibilityElement(_ value: some SignalProducerConvertible<Bool, Never>) -> Self {
         value.producer.take(duringLifetimeOf: self).startWithValues { [weak self] value in
             self?.isAccessibilityElement = value
         }
@@ -331,7 +331,7 @@ extension UIView {
     /// - parameter insets: A `Double` value to set as the padding
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
-    public func padding(_ insets: any SignalProducerConvertible<Double, Never>) -> UIView {
+    public func padding(_ insets: some SignalProducerConvertible<Double, Never>) -> UIView {
         self.padding(insets.producer.map(\.cgFloat).map { UIEdgeInsets.uniform($0) })
     }
     
@@ -339,7 +339,7 @@ extension UIView {
     /// - parameter insets: A reactive `UIEdgeInsets` value to set as the padding
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
-    public func padding(_ insets: any SignalProducerConvertible<UIEdgeInsets, Never>) -> UIView {
+    public func padding(_ insets: some SignalProducerConvertible<UIEdgeInsets, Never>) -> UIView {
         UIView.wrap(configuration: insets.producer.map { WrapConfiguration(insets: $0) }) {
             self
         }
@@ -437,7 +437,7 @@ public func ZStack(
 ///
 public func Line(
     thickness: CGFloat = 1.0,
-    color: any SignalProducerConvertible<UIColor, Never>,
+    color: some SignalProducerConvertible<UIColor, Never>,
     axis: NSLayoutConstraint.Axis = .horizontal
 ) -> UIView {
     UIView.line(thickness: thickness, color: color, axis: axis)
@@ -500,7 +500,7 @@ extension UIView {
     ///
     static func line(
         thickness: CGFloat = 1.0,
-        color: any SignalProducerConvertible<UIColor, Never>,
+        color: some SignalProducerConvertible<UIColor, Never>,
         axis: NSLayoutConstraint.Axis = .horizontal
     ) -> UIView {
         let view = UIView()
@@ -564,18 +564,18 @@ extension Kit where Base: UIView {
     /// Sets the height of the base view to any values sent through the signal
     /// - parameter value: A signal of height values
     /// - returns the `base` view
-    public func height(_ value: any SignalProducerConvertible<Double, Never>) -> Base {
+    public func height(_ value: some SignalProducerConvertible<Double, Never>) -> Base {
         self.base.height(value)
     }
     
     /// Sets the width of the base view to any values sent through the signal
     /// - parameter value: A signal of width values
     /// - returns the `base` view
-    public func width(_ value: any SignalProducerConvertible<Double, Never>) -> Base {
+    public func width(_ value: some SignalProducerConvertible<Double, Never>) -> Base {
         self.base.width(value)
     }
     
-    public func aspectRatio(_ value: any SignalProducerConvertible<Double, Never>) -> Base {
+    public func aspectRatio(_ value: some SignalProducerConvertible<Double, Never>) -> Base {
         self.base.aspectRatio(value)
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -59,8 +59,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func tint<T: SignalProducerConvertible>(_ color: T) -> Self where T.Value == UIColor {
-        self.reactive.tintColor <~ color.producer.eraseError()
+    public func tint(_ color: any SignalProducerConvertible<UIColor, Never>) -> Self {
+        self.reactive.tintColor <~ color.producer
         return self
     }
     
@@ -69,8 +69,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func border<T: SignalProducerConvertible>(_ border: T) -> Self where T.Value == BorderStyle {
-        self.layer.reactive.border <~ border.producer.eraseError()
+    public func border(_ border: any SignalProducerConvertible<BorderStyle, Never>) -> Self {
+        self.layer.reactive.border <~ border.producer
         return self
     }
     
@@ -80,9 +80,12 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func cornerRadius<T: SignalProducerConvertible>(_ value: T, corners: CACornerMask = .all) -> Self where T.Value: CGFloatable {
+    public func cornerRadius(
+        _ value: any SignalProducerConvertible<any CGFloatable, Never>,
+        corners: CACornerMask = .all
+    ) -> Self{
         self.clipsToBounds = true
-        self.layer.reactive.cornerRadius <~ value.producer.map(\.cgFloat).eraseError()
+        self.layer.reactive.cornerRadius <~ value.producer.map(\.cgFloat)
         self.layer.maskedCorners = corners
         return self
     }
@@ -92,8 +95,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func backgroundColor<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == UIColor {
-        self.reactive.backgroundColor <~ value.producer.eraseError()
+    public func backgroundColor(_ value: any SignalProducerConvertible<UIColor, Never>) -> Self {
+        self.reactive.backgroundColor <~ value.producer
         return self
     }
 
@@ -115,8 +118,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func transform<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == CGAffineTransform {
-        value.producer.eraseError()
+    public func transform(_ value: any SignalProducerConvertible<CGAffineTransform, Never>) -> Self {
+        value.producer
             .take(duringLifetimeOf: self)
             .observe(on: QueueScheduler.main)
             .startWithValues { transform in
@@ -129,8 +132,8 @@ extension UIView {
     /// - parameter hidden: A reactive value with a boolean to set as the hidden state
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func hidden<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == Bool {
-        self.reactive.isHidden <~ value.producer.eraseError()
+    public func hidden(_ value: any SignalProducerConvertible<Bool, Never>) -> Self {
+        self.reactive.isHidden <~ value.producer
         return self
     }
     
@@ -138,8 +141,8 @@ extension UIView {
     /// - parameter alpha: A reactive value with a float to set as the alpha
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func alpha<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value: CGFloatable {
-        self.reactive.alpha <~ value.producer.map(\.cgFloat).eraseError()
+    public func alpha(_ value: any SignalProducerConvertible<CGFloatable, Never>) -> Self {
+        self.reactive.alpha <~ value.producer.map(\.cgFloat)
         return self
     }
     
@@ -147,8 +150,8 @@ extension UIView {
     /// - parameter value: A reactive value with a boolean to set as the isUserInteractionEnabled
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func userInteractionEnabled<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == Bool {
-        self.reactive.isUserInteractionEnabled <~ value.producer.eraseError()
+    public func userInteractionEnabled(_ value: any SignalProducerConvertible<Bool, Never>) -> Self {
+        self.reactive.isUserInteractionEnabled <~ value.producer
         return self
     }
     
@@ -163,7 +166,10 @@ extension UIView {
     /// ```
     ///
     @discardableResult
-    public func size<T: SignalProducerConvertible>(width: T? = nil, height: T? = nil) -> Self where T.Value: CGFloatable {
+    public func size(
+        width: (any SignalProducerConvertible<any CGFloatable, Never>)? = nil,
+        height: (any SignalProducerConvertible<any CGFloatable, Never>)? = nil
+    ) -> Self {
         if let width = width {
             _ = self.kit.width(width)
         }
@@ -178,9 +184,9 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func height<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value: CGFloatable {
+    public func height(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
         let constraint: Constraint = self.height(0)
-        constraint.reactive.constant <~ value.producer.map(\.cgFloat).eraseError()
+        constraint.reactive.constant <~ value.producer.map(\.cgFloat)
         return self
     }
     
@@ -189,9 +195,9 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func width<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value: CGFloatable {
+    public func width(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
         let constraint: Constraint = self.width(0)
-        constraint.reactive.constant <~ value.producer.map(\.cgFloat).eraseError()
+        constraint.reactive.constant <~ value.producer.map(\.cgFloat)
         return self
     }
     
@@ -200,7 +206,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func size<T: SignalProducerConvertible>(_ size: T) -> Self where T.Value: CGFloatable {
+    public func size(_ size: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
         self
             .width(size)
             .height(size)
@@ -211,9 +217,9 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies the state of the current view
     @discardableResult
-    public func aspectRatio<T: SignalProducerConvertible>(_ ratio: T) -> Self where T.Value == Double {
+    public func aspectRatio(_ ratio: any SignalProducerConvertible<Double, Never>) -> Self {
         var constraint: Constraint?
-        ratio.producer.take(duringLifetimeOf: self).eraseError().startWithValues { [weak self] multiplier in
+        ratio.producer.take(duringLifetimeOf: self).startWithValues { [weak self] multiplier in
             constraint?.isActive = false
             constraint = self?.aspectRatio(multiplier)
         }
@@ -225,10 +231,10 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func size<T: SignalProducerConvertible>(_ size: T) -> Self where T.Value == CGSize {
+    public func size(_ size: any SignalProducerConvertible<CGSize, Never>) -> Self {
         
-        self.height(size.producer.map(\.height))
-            .width(size.producer.map(\.width))
+        self.height(size.producer.map(\.height).map { $0 as CGFloatable })
+            .width(size.producer.map(\.width).map { $0 as CGFloatable })
     }
     
     // MARK: Accessibility Chainables
@@ -238,8 +244,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityLabel<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value: Stringish {
-        self.reactive.accessibilityLabel <~ value.producer.map(\.stringValue).eraseError()
+    public func accessibilityLabel(_ value: any SignalProducerConvertible<any Stringish, Never>) -> Self {
+        self.reactive.accessibilityLabel <~ value.producer.map(\.stringValue)
         return self
     }
     
@@ -248,8 +254,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityHint<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == String {
-        self.reactive.accessibilityHint <~ value.producer.eraseError()
+    public func accessibilityHint(_ value: any SignalProducerConvertible<String, Never>) -> Self  {
+        self.reactive.accessibilityHint <~ value.producer
         return self
     }
     
@@ -258,8 +264,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityValue<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == String {
-        value.producer.eraseError().take(duringLifetimeOf: self).startWithValues { [weak self] text in
+    public func accessibilityValue(_ value: any SignalProducerConvertible<String, Never>) -> Self {
+        value.producer.take(duringLifetimeOf: self).startWithValues { [weak self] text in
             self?.accessibilityValue = text
         }
         return self
@@ -270,8 +276,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityTraits<T: SignalProducerConvertible>(_ traits: T) -> Self where T.Value == UIAccessibilityTraits {
-        traits.producer.eraseError().take(duringLifetimeOf: self).startWithValues { [weak self] traits in
+    public func accessibilityTraits(_ traits: any SignalProducerConvertible<UIAccessibilityTraits, Never>) -> Self {
+        traits.producer.take(duringLifetimeOf: self).startWithValues { [weak self] traits in
             self?.accessibilityTraits = traits
         }
         return self
@@ -282,8 +288,8 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func isAccessibilityElement<T: SignalProducerConvertible>(_ value: T) -> Self where T.Value == Bool {
-        value.producer.take(duringLifetimeOf: self).eraseError().startWithValues { [weak self] value in
+    public func isAccessibilityElement(_ value: any SignalProducerConvertible<Bool, Never>) -> Self {
+        value.producer.take(duringLifetimeOf: self).startWithValues { [weak self] value in
             self?.isAccessibilityElement = value
         }
         return self
@@ -325,15 +331,15 @@ extension UIView {
     /// - parameter insets: A `CGFloatable` value to set as the padding
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
-    public func padding<T: SignalProducerConvertible>(_ insets: T) -> UIView where T.Value == CGFloatable {
-        self.padding(insets.producer.map(\.cgFloat).eraseError().map { UIEdgeInsets.uniform($0) })
+    public func padding(_ insets: any SignalProducerConvertible<any CGFloatable, Never>) -> UIView {
+        self.padding(insets.producer.map(\.cgFloat).map { UIEdgeInsets.uniform($0) })
     }
     
     /// Chainable method for adding adding to a view
     /// - parameter insets: A reactive `UIEdgeInsets` value to set as the padding
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
-    public func padding<T: SignalProducerConvertible>(_ insets: T) -> UIView where T.Value == UIEdgeInsets {
+    public func padding(_ insets: any SignalProducerConvertible<UIEdgeInsets, Never>) -> UIView {
         UIView.wrap(configuration: insets.producer.map { WrapConfiguration(insets: $0) }) {
             self
         }
@@ -429,11 +435,11 @@ public func ZStack(
 /// - parameter axis: An axis for the direction of the line
 /// - returns: A new `UIView` containing the separator line
 ///
-public func Line<Color: SignalProducerConvertible>(
+public func Line(
     thickness: CGFloat = 1.0,
-    color: Color,
+    color: any SignalProducerConvertible<UIColor, Never>,
     axis: NSLayoutConstraint.Axis = .horizontal
-) -> UIView where Color.Value == UIColor {
+) -> UIView {
     UIView.line(thickness: thickness, color: color, axis: axis)
 }
 
@@ -492,7 +498,11 @@ extension UIView {
     /// - parameter color: Color to give the line, can be reactive or constant
     /// - parameter axis: An axis for the direction of the line
     ///
-    static func line<Color: SignalProducerConvertible>(thickness: CGFloat = 1.0, color: Color, axis: NSLayoutConstraint.Axis = .horizontal) -> UIView where Color.Value == UIColor {
+    static func line(
+        thickness: CGFloat = 1.0,
+        color: any SignalProducerConvertible<UIColor, Never>,
+        axis: NSLayoutConstraint.Axis = .horizontal
+    ) -> UIView {
         let view = UIView()
         
         switch axis {
@@ -504,7 +514,7 @@ extension UIView {
             view.height(thickness)
         }
         
-        view.reactive.backgroundColor <~ color.producer.eraseError()
+        view.reactive.backgroundColor <~ color.producer
         return view
     }
     
@@ -554,18 +564,18 @@ extension Kit where Base: UIView {
     /// Sets the height of the base view to any values sent through the signal
     /// - parameter value: A signal of height values
     /// - returns the `base` view
-    public func height<T: SignalProducerConvertible>(_ value: T) -> Base where T.Value: CGFloatable {
+    public func height(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Base {
         self.base.height(value)
     }
     
     /// Sets the width of the base view to any values sent through the signal
     /// - parameter value: A signal of width values
     /// - returns the `base` view
-    public func width<T: SignalProducerConvertible>(_ value: T) -> Base where T.Value: CGFloatable {
+    public func width(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Base {
         self.base.width(value)
     }
     
-    public func aspectRatio<T: SignalProducerConvertible>(_ value: T) -> Base where T.Value == Double {
+    public func aspectRatio(_ value: any SignalProducerConvertible<Double, Never>) -> Base {
         self.base.aspectRatio(value)
     }
 }

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -81,11 +81,11 @@ extension UIView {
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
     public func cornerRadius(
-        _ value: any SignalProducerConvertible<CGFloat, Never>,
+        _ value: any SignalProducerConvertible<Double, Never>,
         corners: CACornerMask = .all
     ) -> Self{
         self.clipsToBounds = true
-        self.layer.reactive.cornerRadius <~ value.producer
+        self.layer.reactive.cornerRadius <~ value.producer.map(\.cgFloat)
         self.layer.maskedCorners = corners
         return self
     }

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -141,7 +141,7 @@ extension UIView {
     /// - parameter alpha: A reactive value with a float to set as the alpha
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
-    public func alpha(_ value: any SignalProducerConvertible<CGFloatable, Never>) -> Self {
+    public func alpha(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
         self.reactive.alpha <~ value.producer.map(\.cgFloat)
         return self
     }
@@ -240,12 +240,12 @@ extension UIView {
     // MARK: Accessibility Chainables
 
     /// Chainable method for setting the accessibility label on a view
-    /// - parameter value: A reactive value with a `Stringish` to set as the accessibility label
+    /// - parameter value: A reactive value with a `String?` to set as the accessibility label
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityLabel(_ value: any SignalProducerConvertible<any Stringish, Never>) -> Self {
-        self.reactive.accessibilityLabel <~ value.producer.map(\.stringValue)
+    public func accessibilityLabel(_ value: any SignalProducerConvertible<String?, Never>) -> Self {
+        self.reactive.accessibilityLabel <~ value.producer
         return self
     }
     
@@ -328,7 +328,7 @@ extension UIView {
     // MARK: Chainable Composition
     
     /// Chainable method for adding padding to a view
-    /// - parameter insets: A `CGFloatable` value to set as the padding
+    /// - parameter insets: A `Double` value to set as the padding
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
     public func padding(_ insets: any SignalProducerConvertible<Double, Never>) -> UIView {

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -81,11 +81,11 @@ extension UIView {
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
     public func cornerRadius(
-        _ value: any SignalProducerConvertible<any CGFloatable, Never>,
+        _ value: any SignalProducerConvertible<CGFloat, Never>,
         corners: CACornerMask = .all
     ) -> Self{
         self.clipsToBounds = true
-        self.layer.reactive.cornerRadius <~ value.producer.map(\.cgFloat)
+        self.layer.reactive.cornerRadius <~ value.producer
         self.layer.maskedCorners = corners
         return self
     }
@@ -167,8 +167,8 @@ extension UIView {
     ///
     @discardableResult
     public func size(
-        width: (any SignalProducerConvertible<any CGFloatable, Never>)? = nil,
-        height: (any SignalProducerConvertible<any CGFloatable, Never>)? = nil
+        width: (any SignalProducerConvertible<Double, Never>)? = nil,
+        height: (any SignalProducerConvertible<Double, Never>)? = nil
     ) -> Self {
         if let width = width {
             _ = self.kit.width(width)
@@ -184,7 +184,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func height(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
+    public func height(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
         let constraint: Constraint = self.height(0)
         constraint.reactive.constant <~ value.producer.map(\.cgFloat)
         return self
@@ -195,7 +195,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func width(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
+    public func width(_ value: any SignalProducerConvertible<Double, Never>) -> Self {
         let constraint: Constraint = self.width(0)
         constraint.reactive.constant <~ value.producer.map(\.cgFloat)
         return self
@@ -206,7 +206,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func size(_ size: any SignalProducerConvertible<any CGFloatable, Never>) -> Self {
+    public func size(_ size: any SignalProducerConvertible<Double, Never>) -> Self {
         self
             .width(size)
             .height(size)
@@ -233,8 +233,8 @@ extension UIView {
     @discardableResult
     public func size(_ size: any SignalProducerConvertible<CGSize, Never>) -> Self {
         
-        self.height(size.producer.map(\.height).map { $0 as CGFloatable })
-            .width(size.producer.map(\.width).map { $0 as CGFloatable })
+        self.height(size.producer.map(\.height).map(Double.init))
+            .width(size.producer.map(\.width).map(Double.init))
     }
     
     // MARK: Accessibility Chainables
@@ -331,7 +331,7 @@ extension UIView {
     /// - parameter insets: A `CGFloatable` value to set as the padding
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
-    public func padding(_ insets: any SignalProducerConvertible<any CGFloatable, Never>) -> UIView {
+    public func padding(_ insets: any SignalProducerConvertible<Double, Never>) -> UIView {
         self.padding(insets.producer.map(\.cgFloat).map { UIEdgeInsets.uniform($0) })
     }
     
@@ -360,7 +360,7 @@ extension UIView {
     /// - returns: A new view containing the current view with padding
     /// - note: **Wrapping Modifier** this returns a new view
     public func padding(_ insets: CGFloatable) -> UIView {
-        self.padding(SignalProducer<CGFloatable, Never>(value: insets))
+        self.padding(SignalProducer<Double, Never>(value: Double(insets.cgFloat)))
     }
 
     
@@ -564,14 +564,14 @@ extension Kit where Base: UIView {
     /// Sets the height of the base view to any values sent through the signal
     /// - parameter value: A signal of height values
     /// - returns the `base` view
-    public func height(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Base {
+    public func height(_ value: any SignalProducerConvertible<Double, Never>) -> Base {
         self.base.height(value)
     }
     
     /// Sets the width of the base view to any values sent through the signal
     /// - parameter value: A signal of width values
     /// - returns the `base` view
-    public func width(_ value: any SignalProducerConvertible<any CGFloatable, Never>) -> Base {
+    public func width(_ value: any SignalProducerConvertible<Double, Never>) -> Base {
         self.base.width(value)
     }
     

--- a/Sources/KitUI/Extensions/UIKit/UIView.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIView.swift
@@ -244,7 +244,7 @@ extension UIView {
     /// - returns: The current view
     /// - note: **Mutating Modifier** this modifies a property on the current view
     @discardableResult
-    public func accessibilityLabel(_ value: any SignalProducerConvertible<String?, Never>) -> Self {
+    public func accessibilityLabel(_ value: any SignalProducerConvertible<String, Never>) -> Self {
         self.reactive.accessibilityLabel <~ value.producer
         return self
     }


### PR DESCRIPTION
Replacing use of generic function signatures with type constrained protocols with some and any

Kind of ditching `Stringish` and `CGFloatable`. I'm not sure this really provide the convenience that I want them to be. Might return to them in a later version if I can get the ergonomics with type right.