### PR TITLE
Add an on:off: mapper for boolean reactive values

### DIFF
--- a/Sources/KitUI/Extensions/Property.swift
+++ b/Sources/KitUI/Extensions/Property.swift
@@ -24,6 +24,15 @@ extension Property {
     }
 }
 
+extension PropertyProtocol where Value == Bool {
+    public func mapIf<T>(on: T, off: T) -> Property<T> {
+        .init(
+            initial: self.value ? on : off,
+            then: self.producer.mapIf(on: on, off: off)
+        )
+    }
+}
+
 #if os(iOS)
 import UIKit
 extension Property {

--- a/Sources/KitUI/Extensions/Signal.swift
+++ b/Sources/KitUI/Extensions/Signal.swift
@@ -23,6 +23,14 @@ extension Signal {
     }
 }
 
+extension Signal where Value == Bool {
+    public func mapIf<T>(on: T, off: T) -> Signal<T, Error> {
+        self.map {
+            $0 ? on : off
+        }
+    }
+}
+
 extension SignalProducer {
 
     /// Map all values from a signal into an optional    
@@ -56,6 +64,12 @@ extension SignalProducer {
             
             return SignalProducer<ObjectType, Error>(value: value)
         }
+    }
+}
+
+extension SignalProducer where Value == Bool {
+    public func mapIf<T>(on: T, off: T) -> SignalProducer<T, Error> {
+        self.lift { $0.mapIf(on: on, off: off) }
     }
 }
 

--- a/Tests/KitUITests/SignalTests.swift
+++ b/Tests/KitUITests/SignalTests.swift
@@ -1,0 +1,43 @@
+import ReactiveSwift
+import XCTest
+
+final class SignalTests: XCTestCase {
+
+    func testSignalMapIf() throws {
+        let signal = Signal<Bool, Never>.pipe()
+        let inputs = [true, false, false, true, false]
+        
+        let expectation = self.expectation(description: "Wait for values")
+        signal.output.mapIf(on: 10, off: 20).collect().observeResult { result in
+            switch result {
+            case .failure:
+                XCTFail()
+            case .success(let values):
+                XCTAssertEqual(inputs.map { $0 ? 10 : 20 }, values)
+                expectation.fulfill()
+            }
+        }
+        
+        for value in inputs {
+            signal.input.send(value: value)
+        }
+        signal.input.sendCompleted()
+
+        self.waitForExpectations(timeout: 5)
+    }
+    
+    func testProducerMapIf() throws {
+        let producer = SignalProducer<Bool, Never>.init(values: true, false, true, false)
+        let expectation = self.expectation(description: "Wait for values")
+
+        producer.mapIf(on: 10, off: 20)
+            .collect()
+            .startWithValues { values in
+                XCTAssertEqual([10, 20, 10, 20], values)
+                expectation.fulfill()
+            }
+        
+        self.waitForExpectations(timeout: 5)
+    }
+
+}


### PR DESCRIPTION
This is a little syntactic sugar that lets you map a boolean signal into another type. For example...

```swift
self.reactive.backgroundColor <~ booleanSignal.mapIf(on: .black, on: .clear)
```