### PR TITLE
Add preferredContentSize producer and an AccessibleHorizontal stack view

### DIFF
--- a/Sources/KitUI/Extensions/UIKit/UIApplication.swift
+++ b/Sources/KitUI/Extensions/UIKit/UIApplication.swift
@@ -1,0 +1,19 @@
+
+import Foundation
+import ReactiveCocoa
+import ReactiveSwift
+import UIKit
+
+extension Reactive where Base: UIApplication {
+    
+    /// A `SignalProducer` with values for the `UIApplication.preferredContentSizeCatetory`.
+    /// It sends an initial value with the current 
+    var preferredContentSizeCategory: SignalProducer<UIContentSizeCategory, Never> {
+        .merge(
+            SignalProducer<UIContentSizeCategory, Never>(value: self.base.preferredContentSizeCategory),
+            NotificationCenter.default.reactive.notifications(forName: UIContentSizeCategory.didChangeNotification).map { _ in
+                self.base.preferredContentSizeCategory
+            }
+        )
+    }
+}

--- a/Sources/KitUI/StackView.swift
+++ b/Sources/KitUI/StackView.swift
@@ -19,4 +19,16 @@ public func Vertical(@UIViewBuilder builder: () -> [UIView]) -> UIStackView {
 public func Horizontal(@UIViewBuilder builder: () -> [UIView]) -> UIStackView {
     .init(axis: .horizontal, builder: builder)
 }
+
+/// This creates a `UIStackView` that prefers to be horizontal, but switches
+/// to being vertical at accessible font sizes
+public func AccessibleHorizontal(
+    @UIViewBuilder content: () -> [UIView]
+) -> UIStackView {
+    let axis = UIApplication.shared.reactive.preferredContentSizeCategory
+        .map { category -> NSLayoutConstraint.Axis in
+            category.isAccessibilityCategory ? .vertical : .horizontal
+        }
+    return UIStackView(axis: axis, builder: content)
+}
 #endif


### PR DESCRIPTION
Basically this stack view will switch from being horizontal to vertical at accessible text sizes. This sort of assumes you have more vertical space because of scrolling. Admittedly it kind of ignores landscape mode... But that's an improvement for another day...